### PR TITLE
Adds Code support for 20MHz frames

### DIFF
--- a/demos/phases-over-time/phases-over-time.py
+++ b/demos/phases-over-time/phases-over-time.py
@@ -24,6 +24,7 @@ class EspargosDemoPhasesOverTime(PyQt6.QtWidgets.QApplication):
 		# Parse command line arguments
 		parser = argparse.ArgumentParser(description = "ESPARGOS Demo: Show phases over time (single board)")
 		parser.add_argument("hosts", type = str, help = "Comma-separated list of host addresses (IP or hostname) of ESPARGOS controllers")
+		parser.add_argument("--l20", default = False, help = "Operate on 20MHz band", action = "store_true")
 		parser.add_argument("-b", "--backlog", type = int, default = 20, help = "Number of CSI datapoints to average over in backlog")
 		parser.add_argument("-m", "--maxage", type = float, default = 10, help = "Maximum age of CSI datapoints before they are cleared")
 		parser.add_argument("-s", "--shift-peak", default = False, help = "Time-shift CSI so that first peaks align", action = "store_true")
@@ -34,7 +35,7 @@ class EspargosDemoPhasesOverTime(PyQt6.QtWidgets.QApplication):
 		self.pool = espargos.Pool([espargos.Board(host) for host in hosts])
 		self.pool.start()
 		self.pool.calibrate(per_board = False, duration = 2)
-		self.backlog = espargos.CSIBacklog(self.pool, size = self.args.backlog)
+		self.backlog = espargos.CSIBacklog(self.pool, enable_ht40=not self.args.l20, size = self.args.backlog)
 		self.backlog.add_update_callback(self.update)
 		self.backlog.start()
 
@@ -57,10 +58,10 @@ class EspargosDemoPhasesOverTime(PyQt6.QtWidgets.QApplication):
 
 	def update(self):
 		if self.backlog.nonempty():
-			csi_backlog_ht40 = self.backlog.get_ht40()
-			csi_ht40_shifted = espargos.util.shift_to_firstpeak(csi_backlog_ht40) if self.args.shift_peak else csi_backlog_ht40
-			csi_interp_ht40 = espargos.util.csi_interp_iterative(csi_ht40_shifted)
-			csi_flat = np.reshape(csi_interp_ht40, (-1, csi_interp_ht40.shape[-1]))
+			csi_backlog = self.backlog.get_csi()
+			csi_shifted = espargos.util.shift_to_firstpeak(csi_backlog) if self.args.shift_peak else csi_backlog
+			csi_interp = espargos.util.csi_interp_iterative(csi_shifted)
+			csi_flat = np.reshape(csi_interp, (-1, csi_interp.shape[-1]))
 
 			# TODO: Deal with non-synchronized multi-board setup
 			csi_by_antenna = espargos.util.csi_interp_iterative(np.transpose(csi_flat))


### PR DESCRIPTION
This PR adds the option to store 20MHz CSI data in the backlog object.
I've named that L20 since it's 20MHz, and the buffer name is lltf (by opposition to HT40's htltf). But I guess that naming could be changed if you have a better idea.

The backlog object does not really support handling both HT40 and L20 data at the same time, nor changing type at runtime. 
But I don't see where that would be practical anyways.

I've made a getter function to get the CSI data regardless of the type, but kept the previous `get_ht40()` for compatibility.

And I've adapted the demo scripts to use that generic function, with a cli parameter to choose HT40 or L20 operation.
I've tried all of them (except the combined array since I only have access to one) and they all appear to run fine in both modes without crashing, and the visual output seems to make sense.
But I have not precisely tested if all the math is correct. Especially since it seems that the center frequencies don't have data, that hole might affect some computations.

